### PR TITLE
Linux export

### DIFF
--- a/main.js
+++ b/main.js
@@ -75,32 +75,11 @@ function showExportDialog(event, gqlSchema, gqlResolvers, sqlScripts, env) {
       createFile('db/createTables.sql', sqlScripts);
       createFile('.env', env);
 
-      const output = fs.createWriteStream(result + '/apollo-server.zip');
+      const output = fs.createWriteStream(result + '/apollo-server.zip', 
+        // { autoClose: false }
+      );
       const archive = archiver('zip', {
         zlib: { level: 9 } // Sets the compression level.
-      });
-
-
-
-      // listen for all archive data to be written and output associated details
-      output.on('close', function () {
-        console.log('Zip file size is ', archive.pointer() + ' total bytes');
-        console.log('Archived zip file is complete.');
-
-        //commented out to fix Linux export
-        // createFile('graphql/schema.js', '');
-        // createFile('graphql/resolvers.js', '');
-        // createFile('db/createTables.sql', '');
-        // createFile('.env', '');
-
-        dialog.showMessageBox(win,
-          {
-            type: "info",
-            buttons: ["Ok"],
-            message: "Export Successful!",
-            detail: 'File saved to ' + result + '/apollo-server.zip'
-          }
-        )
       });
 
       // good practice to catch warnings (ie stat failures and other non-blocking errors)
@@ -122,6 +101,28 @@ function showExportDialog(event, gqlSchema, gqlResolvers, sqlScripts, env) {
       // finalize the archive (ie we are done appending files but streams have to finish yet)
       // 'close' will be fired afterwards
       archive.finalize();
+
+
+      // listen for all archive data to be written and output associated details
+      output.on('close', function () {
+        console.log('Zip file size is ', archive.pointer() + ' total bytes');
+        console.log('Archived zip file is complete.');
+
+        //commented out to fix Linux export
+        createFile('graphql/schema.js', '');
+        createFile('graphql/resolvers.js', '');
+        createFile('db/createTables.sql', '');
+        createFile('.env', '');
+
+        dialog.showMessageBox(win,
+          {
+            type: "info",
+            buttons: ["Ok"],
+            message: "Export Successful!",
+            detail: 'File saved to ' + result + '/apollo-server.zip'
+          }
+        )
+      });
     }
   );
 }

--- a/main.js
+++ b/main.js
@@ -87,14 +87,16 @@ function showExportDialog(event, gqlSchema, gqlResolvers, sqlScripts, env) {
         console.log('Zip file size is ', archive.pointer() + ' total bytes');
         console.log('Archived zip file is complete.');
 
-        createFile('graphql/schema.js', '');
-        createFile('graphql/resolvers.js', '');
-        createFile('db/createTables.sql', '');
-        createFile('.env', '');
+        //commented out to fix Linux export
+        // createFile('graphql/schema.js', '');
+        // createFile('graphql/resolvers.js', '');
+        // createFile('db/createTables.sql', '');
+        // createFile('.env', '');
 
         dialog.showMessageBox(win,
           {
             type: "info",
+            buttons: ["Ok"],
             message: "Export Successful!",
             detail: 'File saved to ' + result + '/apollo-server.zip'
           }


### PR DESCRIPTION
Fixed Linux export 
- Moved archive data close event listener to end of showExportDialog async function. Now, files are properly refreshed after export runs without wiping out exported data.
- Added OK button to "Export Successful" message box to allow the user to continue using the app after export

Needs testing on Windows/Mac before it is merged with master.